### PR TITLE
Free up LazySuite precache while getting tests

### DIFF
--- a/nose/suite.py
+++ b/nose/suite.py
@@ -92,8 +92,10 @@ class LazySuite(unittest.TestSuite):
 
     def _get_tests(self):
         log.debug("precache is %s", self._precache)
-        for test in self._precache:
-            yield test
+        while self._precache:
+            # because the precache holds test cases, it is important 
+            # to remove them so that memory can be freed for longer tests
+            yield self._precache.pop(0)
         if self.test_generator is None:
             return
         for test in self.test_generator:


### PR DESCRIPTION
`LazySuite` will, by default, keep a cache of tests that are being added to it. This cache never gets removed, so when running a very large test suite, older test cases do not get freed, causing memory pressure over the long term.

 This patch instead removes elements from the cache as they get read.  Since the test are supposed to be iterated over just once, I believe this does not change the outward spec of this class, even if internal details have changed. 